### PR TITLE
Fix for breaking error on empty divs

### DIFF
--- a/js/imgLiquid.js
+++ b/js/imgLiquid.js
@@ -109,7 +109,7 @@ imgLiquid.injectCss = '.imgLiquid img {visibility:hidden}';
 
 				// MAIN >> each for image
 
-				var settings,
+				var settings = imgLiquidRoot.settings,
 				$imgBoxCont = $(this),
 				$img = $('img:first',$imgBoxCont);
 				if (!$img.length) {onError(); return;}


### PR DESCRIPTION
When applied in divs with no image, the error callback is triggered before the settings object is defined, raising a TypeError that breaks the whole process.
