### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
 ![ScreenShot](https://raw.github.com/karacas/imgLiquid/master/tests/logoimgliquid.png)
 
 imgLiquid v0.9.944 / 11-04-2013
-#####A jQuery Plugin to resize images to fit in a container.
+##### A jQuery Plugin to resize images to fit in a container.
 Alejandro Emparan (karacas) / @krc_ale
 Dual licensed under the MIT and GPL licenses.
 ## 
-#Usage
+# Usage
 
-####Include:
+#### Include:
 ```html
 <script src="js/imgLiquid-min.js"></script>
 ```
 
-####js:
+#### js:
 ```js
 $(document).ready(function() {
 	$(".imgLiquidFill").imgLiquid();
 });
 ```
 
-####Html:
+#### Html:
 ```html
 <div class="imgLiquidFill imgLiquid" style="width:300px; height:200px;">
 	<img alt="Woody" src="woody.jpg" />
 </div>
 ```
  
-####View in action:
+#### View in action:
 http://goo.gl/Wk8bU
-####or play with it:
+#### or play with it:
 http://jsfiddle.net/karacas/3CRx7/#base
 http://codepen.io/karacas/pen/nlugd
 ## 
-###Features:
+### Features:
 ```
 	- Uses CSS Background-size when is available. (new!)
     - Bootstrap compatible.
@@ -46,7 +46,7 @@ http://codepen.io/karacas/pen/nlugd
 	- All browsers (Incl. ie6).
 ```
  
-###Options:
+### Options:
 ```
 
     >js


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
